### PR TITLE
Fix/checkbox not saving

### DIFF
--- a/extendevent.php
+++ b/extendevent.php
@@ -57,8 +57,8 @@ if (!confirm_sesskey()) {
 
 $response = [];
 
-$system = setup_system();
-$event = get_event($system, $id);
+$client = setup();
+$event = get_event($client, $id);
 if (!$event) {
     header('HTTP/1.1 500 Error');
     $response['message'] = "error with get_event";
@@ -70,7 +70,7 @@ if (!$event) {
     $posttime = $timestamp->format('Y-m-d\TH:i:s.u\Z');
     $response['posttime'] = $posttime;
     $data->expirationDate = $posttime;
-    $result = extend_event($system, $data);
+    $result = extend_event($client, $data);
     if (!$result) {
         header('HTTP/1.1 500 Error');
         $response['message'] = "error with extend_event";

--- a/extendevent.php
+++ b/extendevent.php
@@ -57,7 +57,7 @@ if (!confirm_sesskey()) {
 
 $response = [];
 
-$client = setup();
+$client = setup_system();
 $event = get_event($client, $id);
 if (!$event) {
     header('HTTP/1.1 500 Error');

--- a/lang/en/crucible.php
+++ b/lang/en/crucible.php
@@ -48,7 +48,8 @@ $string['modulenameplural'] = 'Crucibles';
 $string['pluginname'] = 'Crucible';
 
 // Plugin settings.
-$string['alloyapiurl'] = 'Alloy API Base URL';
+$string['alloyapiurl'] = 'Alloy API Base URL (Server)';
+$string['alloyapiclienturl'] = 'Alloy API Base URL (Browser)';
 $string['vmapp'] = 'Display Mode';
 $string['vmappurl'] = 'VM App Base URL';
 $string['playerappurl'] = 'Player Base URL';
@@ -64,7 +65,8 @@ $string['configvmapp'] = 'This determines whether the VM app is embedded or whet
 $string['configvmappurl'] = 'Base URL for VM app instance without trailing /.';
 $string['configplayerappurl'] = 'Base URL for Player instance without trailing /.';
 $string['configsteamfitterapiurl'] = 'Base URL for Steamfitter API instance without trailing /.';
-$string['configalloyapiurl'] = 'Base URL for Alloy API instance without trailing /.';
+$string['configalloyapiurl'] = 'Base URL for Alloy API used by server-side PHP (e.g., http://host.docker.internal:4402/api). Without trailing /.';
+$string['configalloyapiclienturl'] = 'Base URL for Alloy API used by browser JavaScript (e.g., http://localhost:4402/api). Without trailing /. Leave empty to use same as server URL.';
 $string['configeventtemplate'] = 'Event Template GUID to be launched.';
 $string['configautocomplete'] = 'Display list of Event Templates in a dropdown or a searchable text box.';
 $string['configshowfailed'] = 'Show failed Events in the history table.';

--- a/lang/en/crucible.php
+++ b/lang/en/crucible.php
@@ -59,7 +59,7 @@ $string['eventtemplate'] = 'Event Template';
 $string['selectname'] = 'Search for an Event Template by name';
 $string['showfailed'] = 'Show Failed';
 
-$string['configissuerid'] = 'This is the integer value for the issuer.';
+$string['configissuerid'] = 'OAuth2 issuer for authentication with Alloy API. The issuer must be configured in Site administration > Server > OAuth 2 services.';
 $string['configvmapp'] = 'This determines whether the VM app is embedded or whether a link to player is displayed.';
 $string['configvmappurl'] = 'Base URL for VM app instance without trailing /.';
 $string['configplayerappurl'] = 'Base URL for Player instance without trailing /.';

--- a/lib.php
+++ b/lib.php
@@ -132,6 +132,7 @@ function crucible_add_instance($crucible, $mform) {
 
     $crucible->created = time();
     $crucible->grade = 100; // Default.
+    $crucible->extendevent = empty($crucible->extendevent) ? 0 : 1;
     $crucible->id = $DB->insert_record('crucible', $crucible);
 
     // Do the processing required after an add or an update.
@@ -164,6 +165,7 @@ function crucible_update_instance(stdClass $crucible, $mform) {
 
     // Update the database.
     $crucible->id = $crucible->instance;
+    $crucible->extendevent = empty($crucible->extendevent) ? 0 : 1;
     $DB->update_record('crucible', $crucible);
 
     // Do the processing required after an add or an update.

--- a/settings.php
+++ b/settings.php
@@ -64,6 +64,9 @@ if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configtext('crucible/alloyapiurl',
         get_string('alloyapiurl', 'crucible'), get_string('configalloyapiurl', 'crucible'), "", PARAM_URL, 60));
 
+    $settings->add(new admin_setting_configtext('crucible/alloyapiclienturl',
+        get_string('alloyapiclienturl', 'crucible'), get_string('configalloyapiclienturl', 'crucible'), "", PARAM_URL, 60));
+
     $settings->add(new admin_setting_configtext('crucible/playerappurl',
         get_string('playerappurl', 'crucible'), get_string('configplayerappurl', 'crucible'), "", PARAM_URL, 60));
 

--- a/templates/clock.mustache
+++ b/templates/clock.mustache
@@ -35,7 +35,7 @@ DM20-0196
 	    }
 }}
 
-<div id="timerdiv" style="display:none; margin-bottom: 1rem;">
+<div id="timerdiv" style="margin-bottom: 1rem;">
     <span id="timer"></span>
     {{#extend}}
     <button id="extend-event" class="btn btn-primary">{{extend}}</button>

--- a/templates/form.mustache
+++ b/templates/form.mustache
@@ -35,7 +35,6 @@ DM20-0196
 		          "url": "url"
             }
 }}
-{{> mod_crucible/clock}}
 <span>
   <form id="lab_form" action="{{url}}" method="post" style="display:inline">
       <input id="event" type="hidden" name="event" value="" />

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM20-0196
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026050701;
+$plugin->version = 2026050702;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;
@@ -58,4 +58,4 @@ $plugin->dependencies = [];
 $plugin->maturity = MATURITY_BETA;
 
 // This is the named version.
-$plugin->release = '0.1.3';
+$plugin->release = '0.1.4';

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM20-0196
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026050702;
+$plugin->version = 2026050703;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;
@@ -58,4 +58,4 @@ $plugin->dependencies = [];
 $plugin->maturity = MATURITY_BETA;
 
 // This is the named version.
-$plugin->release = '0.1.4';
+$plugin->release = '0.1.5';

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM20-0196
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026050703;
+$plugin->version = 2026050901;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;
@@ -58,4 +58,4 @@ $plugin->dependencies = [];
 $plugin->maturity = MATURITY_BETA;
 
 // This is the named version.
-$plugin->release = '0.1.5';
+$plugin->release = '0.1.6';

--- a/version.php
+++ b/version.php
@@ -42,7 +42,7 @@ DM20-0196
 defined('MOODLE_INTERNAL') || die();
 
 // This is the version of the plugin.
-$plugin->version = 2026030104;
+$plugin->version = 2026050701;
 
 // This is the version of Moodle this plugin requires.
 $plugin->requires = 2025041400;
@@ -58,4 +58,4 @@ $plugin->dependencies = [];
 $plugin->maturity = MATURITY_BETA;
 
 // This is the named version.
-$plugin->release = '0.1.2';
+$plugin->release = '0.1.3';

--- a/view.php
+++ b/view.php
@@ -301,7 +301,7 @@ $renderer->display_form($url, $object->crucible->eventtemplateid, $id, $attempti
 if ($object->event) {
 
     $extend = false;
-    if ($object->systemauth && !empty($crucible->extendevent)) {
+    if ($object->userauth && !empty($crucible->extendevent)) {
         $extend = true;
     }
 

--- a/view.php
+++ b/view.php
@@ -273,7 +273,7 @@ echo $renderer->header();
 
 $license_info = null;
 
-if ($crucible->showcontentlicense) {
+if (!empty($crucible->showcontentlicense)) {
     $license_id = $crucible->contentlicense;
     $license_info = license_manager::get_license_by_shortname($license_id);
 }
@@ -301,7 +301,7 @@ $renderer->display_form($url, $object->crucible->eventtemplateid, $id, $attempti
 if ($object->event) {
 
     $extend = false;
-    if ($object->systemauth && $crucible->extendevent) {
+    if ($object->systemauth && !empty($crucible->extendevent)) {
         $extend = true;
     }
 

--- a/view.php
+++ b/view.php
@@ -295,9 +295,6 @@ if ($object->openattempt && $object->openattempt->userid == $USER->id) {
     }
 }
 
-// TODO if user is in two attempts, ask which attempt they want to be in, and redirect them to a url with that attempt
-$renderer->display_form($url, $object->crucible->eventtemplateid, $id, $attemptid, $formattempts, $sharecode);
-
 if ($object->event) {
 
     $extend = false;
@@ -318,6 +315,9 @@ if ($object->event) {
 } else if ($showgrade) {
     $renderer->display_grade($crucible);
 }
+
+// TODO if user is in two attempts, ask which attempt they want to be in, and redirect them to a url with that attempt
+$renderer->display_form($url, $object->crucible->eventtemplateid, $id, $attemptid, $formattempts, $sharecode);
 
 $PAGE->requires->js_call_amd('mod_crucible/invite', 'init', [['id' => $cm->id]]);
 

--- a/view.php
+++ b/view.php
@@ -354,13 +354,18 @@ if ($object->event && $object->event->status === 'Active') {
 
 $PAGE->requires->js_call_amd('mod_crucible/view', 'init');
 
+$alloyapiclienturl = get_config('crucible', 'alloyapiclienturl');
+if (empty($alloyapiclienturl)) {
+    $alloyapiclienturl = $alloyapiurl;
+}
+
 $accesstoken = get_token($object->userauth);
 $configdata = [
     'token' => $accesstoken,
     'state' => $status,
     'event' => $eventid,
     'view' => $viewid,
-    'alloy_api_url' => $alloyapiurl,
+    'alloy_api_url' => $alloyapiclienturl,
     'vm_app_url' => $vmappurl,
     'player_app_url' => $playerappurl,
 ];


### PR DESCRIPTION
## Summary
  Fixes extend button not displaying in production and improves plugin configuration settings.

  ## Changes

  ### Extend Button Fixes
  - **Fix template visibility**: Removed `display:none` from clock template that prevented timer/extend button from showing
  - **Fix duplicate rendering**: Removed clock partial include from form template that caused two timerdiv elements
  - **Fix layout**: Moved clock display above control buttons to prevent overlap
  - **Root cause**: Template had `display:none` since 2020 (commit 18f10f9) but JavaScript never removed it

  ### Configuration Improvements
  - **Add browser-side API URL setting**: Added `alloyapiclienturl` for JavaScript to use `localhost` while server uses `host.docker.internal` (Docker networking)
  - **Update Moodle config script**: Added alloyapiclienturl configuration in post_configure.sh
  - **Improve help text**: Changed issuerid help text to match UI (shows dropdown with names, not integer values)

  ### Authentication
  - **Use user auth for extend**: Changed extend button to use user OAuth token instead of system account (works in production without system OAuth setup)

  ## Test Plan
  - [x] Extend button appears when setting enabled and event active
  - [x] Button positioned correctly above control buttons
  - [x] No duplicate timer displays
  - [x] Browser can reach Alloy API when Moodle in Docker
  - [x] Checkbox settings save correctly